### PR TITLE
Add stock price download notebook

### DIFF
--- a/notebooks/04_download_stock_prices.ipynb
+++ b/notebooks/04_download_stock_prices.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7537e3ef",
+   "metadata": {},
+   "source": [
+    "# 株価データの取得と保存\n",
+    "このノートブックでは、companiesテーブルに登録された企業のYahoo Financeティッカーを用いて株価データを取得し、PostgreSQLのstock_pricesテーブルに保存します。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01847e8c",
+   "metadata": {},
+   "source": [
+    "## ライブラリのインポート"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "303271f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from datetime import datetime\n",
+    "import pandas as pd\n",
+    "import yfinance as yf\n",
+    "from sqlalchemy import create_engine, text\n",
+    "from sqlalchemy.engine import URL\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "603960fc",
+   "metadata": {},
+   "source": [
+    "## データベースからティッカー一覧を取得"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adb7cb1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# .envから接続情報を読み込み\n",
+    "from dotenv import load_dotenv\n",
+    "load_dotenv('../.env')\n",
+    "\n",
+    "# SQLAlchemy用の接続URLを作成\n",
+    "database_url = URL.create(\n",
+    "    drivername='postgresql+psycopg2',\n",
+    "    username=os.getenv('POSTGRES_USER'),\n",
+    "    password=os.getenv('POSTGRES_PASSWORD'),\n",
+    "    host=os.getenv('POSTGRES_HOST', 'localhost'),\n",
+    "    port=os.getenv('POSTGRES_PORT', '5432'),\n",
+    "    database=os.getenv('POSTGRES_DB'),\n",
+    ")\n",
+    "engine = create_engine(database_url)\n",
+    "\n",
+    "# companiesテーブルから company_id と yahoo_ticker を取得\n",
+    "df_companies = pd.read_sql('SELECT id as company_id, yahoo_ticker FROM companies WHERE yahoo_ticker IS NOT NULL', engine)\n",
+    "tickers = df_companies['yahoo_ticker'].tolist()\n",
+    "print(f'{len(tickers)} tickers loaded')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49353005",
+   "metadata": {},
+   "source": [
+    "## yfinanceで株価データを取得"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b8ae05f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = '2015-01-01'\n",
+    "end = datetime.today().strftime('%Y-%m-%d')\n",
+    "\n",
+    "# 一度に大量ティッカーを渡すと失敗することがあるため、50件ずつに分割\n",
+    "chunks = [tickers[i:i+50] for i in range(0, len(tickers), 50)]\n",
+    "all_data = []\n",
+    "for chunk in chunks:\n",
+    "    try:\n",
+    "        data = yf.download(' '.join(chunk), start=start, end=end, threads=True, group_by='ticker', auto_adjust=False)\n",
+    "    except Exception as e:\n",
+    "        print(f'failed to download chunk {chunk}: {e}')\n",
+    "        continue\n",
+    "    if isinstance(data.columns, pd.MultiIndex):\n",
+    "        for ticker in chunk:\n",
+    "            if ticker in data.columns.levels[1]:\n",
+    "                df = data.xs(ticker, level=1, axis=1).copy()\n",
+    "                df['ticker'] = ticker\n",
+    "                all_data.append(df.reset_index())\n",
+    "    else:\n",
+    "        data['ticker'] = chunk[0]\n",
+    "        all_data.append(data.reset_index())\n",
+    "\n",
+    "stock_df = pd.concat(all_data, ignore_index=True)\n",
+    "print(stock_df.head())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd0306f5",
+   "metadata": {},
+   "source": [
+    "## データ整形"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "515ca900",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# companies情報と結合してcompany_idを付与\n",
+    "stock_df = stock_df.merge(df_companies, left_on='ticker', right_on='yahoo_ticker', how='left')\n",
+    "stock_df.rename(columns={\n",
+    "    'Date': 'date',\n",
+    "    'Open': 'open',\n",
+    "    'High': 'high',\n",
+    "    'Low': 'low',\n",
+    "    'Close': 'close',\n",
+    "    'Adj Close': 'adj_close',\n",
+    "    'Volume': 'volume'\n",
+    "}, inplace=True)\n",
+    "stock_df = stock_df[['company_id', 'date', 'open', 'high', 'low', 'close', 'adj_close', 'volume']]\n",
+    "stock_df.dropna(subset=['company_id'], inplace=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7098bd27",
+   "metadata": {},
+   "source": [
+    "## データベースへ保存"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e3f5ba3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# stock_pricesテーブルにデータを書き込む\n",
+    "# テーブルが存在しなければ作成、既存なら追記モード\n",
+    "stock_df.to_sql('stock_prices', con=engine, if_exists='append', index=False, method='multi', chunksize=1000)\n",
+    "print('✅ データ保存完了')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add notebook to fetch Yahoo Finance data for companies and save into `stock_prices`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651b90f7c0832f826cc968fbc94f53